### PR TITLE
修复TextField失去焦点时,controller.clear()报错

### DIFF
--- a/lib/ui/page/search/search_delegate.dart
+++ b/lib/ui/page/search/search_delegate.dart
@@ -71,12 +71,17 @@ class DefaultSearchDelegate extends SearchDelegate {
   Widget buildSuggestions(BuildContext context) {
     return MultiProvider(
       providers: [
-        ChangeNotifierProvider<SearchHistoryModel>(
-            create: (_) => _searchHistoryModel),
-        ChangeNotifierProvider<SearchHotKeyModel>(
-            create: (_) => _searchHotKeyModel),
+        ChangeNotifierProvider<SearchHistoryModel>.value(value: _searchHistoryModel),
+        ChangeNotifierProvider<SearchHotKeyModel>.value(value: _searchHotKeyModel),
       ],
       child: SearchSuggestions(delegate: this),
     );
+  }
+
+  @override
+  void close(BuildContext context, result) {
+    _searchHistoryModel.dispose();
+    _searchHotKeyModel.dispose();
+    super.close(context, result);
   }
 }

--- a/lib/ui/page/user/login_field_widget.dart
+++ b/lib/ui/page/user/login_field_widget.dart
@@ -167,7 +167,9 @@ class _LoginTextFieldClearIconState extends State<LoginTextFieldClearIcon> {
       },
       child: InkWell(
           onTap: () {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
               widget.controller.clear();
+            });
           },
           child: Icon(CupertinoIcons.clear,
               size: 30, color: Theme.of(context).hintColor)),


### PR DESCRIPTION
修复搜索页面viewModel被dispose的问题
修复TextField失去焦点时,controller.clear()报错的问题 https://github.com/phoenixsky/fun_android_flutter/issues/52